### PR TITLE
[Refact] 코드리뷰 반영: 뷰 모델에서 String 값으로 이전

### DIFF
--- a/app/src/main/java/com/yourssu/unscramble/presentation/end/EndViewModel.kt
+++ b/app/src/main/java/com/yourssu/unscramble/presentation/end/EndViewModel.kt
@@ -1,9 +1,12 @@
 package com.yourssu.unscramble.presentation.end
 
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 
 class EndViewModel : ViewModel() {
-    val result = MutableLiveData("Time out!") //Todo 이 부분은 분기처리해야 함
-    val score = MutableLiveData("70") //Todo 여기도 나중에 처리
+    private val _result: MutableStateFlow<String> = MutableStateFlow("Time out!")
+    val result: MutableStateFlow<String> = _result
+
+    private val _score: MutableStateFlow<Int> = MutableStateFlow(100)
+    val score: MutableStateFlow<Int> = _score
 }

--- a/app/src/main/java/com/yourssu/unscramble/presentation/end/EndViewModel.kt
+++ b/app/src/main/java/com/yourssu/unscramble/presentation/end/EndViewModel.kt
@@ -5,8 +5,5 @@ import androidx.lifecycle.ViewModel
 
 class EndViewModel : ViewModel() {
     val result = MutableLiveData("Time out!") //Todo 이 부분은 분기처리해야 함
-    val retry = MutableLiveData("Retry")
-    val home = MutableLiveData("Home")
-    val score_title = MutableLiveData("Score: ")
     val score = MutableLiveData("70") //Todo 여기도 나중에 처리
 }

--- a/app/src/main/java/com/yourssu/unscramble/presentation/end/EndViewModel.kt
+++ b/app/src/main/java/com/yourssu/unscramble/presentation/end/EndViewModel.kt
@@ -2,11 +2,12 @@ package com.yourssu.unscramble.presentation.end
 
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 class EndViewModel : ViewModel() {
     private val _result: MutableStateFlow<String> = MutableStateFlow("Time out!")
-    val result: MutableStateFlow<String> = _result
+    val result: StateFlow<String> = _result
 
-    private val _score: MutableStateFlow<Int> = MutableStateFlow(100)
-    val score: MutableStateFlow<Int> = _score
+    private val _score: MutableStateFlow<Int> = MutableStateFlow(0)
+    val score: StateFlow<Int> = _score
 }

--- a/app/src/main/java/com/yourssu/unscramble/presentation/start/StartFragment.kt
+++ b/app/src/main/java/com/yourssu/unscramble/presentation/start/StartFragment.kt
@@ -13,7 +13,6 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class StartFragment : BindFragment<FragmentStartBinding>() {
 
-    private val viewModel: StartViewModel by viewModels()
     override fun setBinding(layoutInflater: LayoutInflater): FragmentStartBinding {
         return FragmentStartBinding.inflate(layoutInflater)
     }
@@ -21,7 +20,6 @@ class StartFragment : BindFragment<FragmentStartBinding>() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        binding.viewModel = viewModel
         binding.lifecycleOwner = viewLifecycleOwner
 
         binding.btnStart.setOnClickListener {

--- a/app/src/main/java/com/yourssu/unscramble/presentation/start/StartViewModel.kt
+++ b/app/src/main/java/com/yourssu/unscramble/presentation/start/StartViewModel.kt
@@ -1,9 +1,0 @@
-package com.yourssu.unscramble.presentation.start
-
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
-
-class StartViewModel : ViewModel() {
-    val title = MutableLiveData("UNSCRAMBLE")
-    val btn = MutableLiveData("START")
-}

--- a/app/src/main/res/layout/fragment_end.xml
+++ b/app/src/main/res/layout/fragment_end.xml
@@ -53,7 +53,7 @@
                 android:layout_height="wrap_content"
                 android:gravity="center_vertical"
                 android:textColor="@color/white"
-                app:text="@{viewModel.score_title}" />
+                app:text="@{@string/score}"/>
 
             <com.yourssu.design.system.atom.Text
                 android:id="@+id/tv_score2"
@@ -75,7 +75,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:rounding="@{8}"
             app:size="@{BoxButton.Large}"
-            app:text="@{viewModel.retry}"
+            app:text="@{@string/retry}"
             app:type="@{BoxButton.FILLED}" />
 
         <com.yourssu.design.system.atom.BoxButton
@@ -89,7 +89,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:rounding="@{8}"
             app:size="@{BoxButton.Large}"
-            app:text="@{viewModel.home}"
+            app:text="@{@string/home}"
             app:type="@{BoxButton.LINE}" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_end.xml
+++ b/app/src/main/res/layout/fragment_end.xml
@@ -53,9 +53,6 @@
                 android:layout_height="wrap_content"
                 android:gravity="center_vertical"
                 android:textColor="@color/white"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/imageView"
                 app:text="@{viewModel.score_title}" />
 
             <com.yourssu.design.system.atom.Text
@@ -64,9 +61,6 @@
                 android:layout_height="wrap_content"
                 android:gravity="center_vertical"
                 android:textColor="@color/white"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/imageView"
                 app:text="@{viewModel.score}" />
         </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_start.xml
+++ b/app/src/main/res/layout/fragment_start.xml
@@ -6,9 +6,6 @@
     <data>
         <import type="com.yourssu.design.system.atom.Text" />
         <import type="com.yourssu.design.system.atom.BoxButton"/>
-        <variable
-            name="viewModel"
-            type="com.yourssu.unscramble.presentation.start.StartViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -36,7 +33,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/imageView"
-            app:text="@{viewModel.title}"/>
+            app:text="@{@string/title}" />
 
 
         <com.yourssu.design.system.atom.BoxButton
@@ -51,9 +48,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:rounding="@{8}"
             app:size="@{BoxButton.Large}"
-            app:text="@{viewModel.btn}"
+            app:text="@{@string/start}"
             app:type="@{BoxButton.FILLED}" />
-
-
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,9 @@
     <string name="app_name">yourssu_rookies_unscramble</string>
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="home">Home</string>
+    <string name="score">Score:</string>
+    <string name="retry">Retry</string>
+    <string name="title">UNSCRAMBLE</string>
+    <string name="start">START</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,5 @@
 <resources>
     <string name="app_name">unscramble</string>
-    <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="home">Home</string>
     <string name="score">Score:</string>
     <string name="retry">Retry</string>


### PR DESCRIPTION
## Summary

> 불변하는 값들을 뷰모델에서 뮤터블라이브 데이터로 넣어주는게 마음에 걸렸었는데, 유리언니가 저번에말했던 것처럼 string으로 관리할 수 있는 방법이 있어서 불변값 뷰모델에서 싹 지웠습니다. 

`            app:text="@{@string/home}"`

추가로 변경 값만 뷰모델에 남겨두어서 backing property로 수정해두었습니다. 

## Describe your changes
N/A

## Issue

> N/A

## To reviewers
대면 코드리뷰 및 코드리뷰 반영
